### PR TITLE
CEF Progress listener

### DIFF
--- a/README.desktop.md
+++ b/README.desktop.md
@@ -15,6 +15,10 @@ LaunchedEffect(Unit) {
 Then, run your app once and it will download the JCEF Bundle to the install directory. 
 After that, just restart your app and it will work properly.
 
+> **Note**
+> Make sure to exclude the `installDir` from upstreaming by adding it to the `.gitignore`.
+> The downloaded files are platform-specific and therefore differ to each user.
+
 Please use the following example as a reference.
 ```kotlin
 fun main() = application {

--- a/desktopApp/src/jvmMain/kotlin/main.kt
+++ b/desktopApp/src/jvmMain/kotlin/main.kt
@@ -7,6 +7,7 @@ import com.multiplatform.webview.web.Cef
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import kotlin.math.max
 
 fun main() = application {
     Window(onCloseRequest = ::exitApplication) {
@@ -20,7 +21,7 @@ fun main() = application {
                     installDir = File("jcef-bundle")
                 }, initProgress = {
                     onDownloading {
-                        downloading = it
+                        downloading = max(it, 0F)
                     }
                     onInitialized {
                         initialized = true

--- a/desktopApp/src/jvmMain/kotlin/main.kt
+++ b/desktopApp/src/jvmMain/kotlin/main.kt
@@ -1,33 +1,52 @@
 import androidx.compose.material.Text
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.multiplatform.webview.MainWebView
 import com.multiplatform.webview.web.Cef
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 fun main() = application {
     Window(onCloseRequest = ::exitApplication) {
         var restartRequired by remember { mutableStateOf(false) }
+        var downloading by remember { mutableStateOf(0F) }
+        var initialized by remember { mutableStateOf(false) }
 
         LaunchedEffect(Unit) {
-            Cef.init(builder = {
-                installDir = File("jcef-bundle")
-            }, onError = {
-                it.printStackTrace()
-            }) {
-                restartRequired = true
+            withContext(Dispatchers.IO) {
+                Cef.init(builder = {
+                    installDir = File("jcef-bundle")
+                }, initProgress = {
+                    onDownloading {
+                        downloading = it
+                    }
+                    onInitialized {
+                        initialized = true
+                    }
+                }, onError = {
+                    it.printStackTrace()
+                }, onRestartRequired = {
+                    restartRequired = true
+                })
             }
         }
 
         if (restartRequired) {
             Text(text = "Restart required.")
         } else {
-            MainWebView()
+            if (initialized) {
+                MainWebView()
+            } else {
+                Text(text = "Downloading $downloading%")
+            }
+        }
+
+        DisposableEffect(Unit) {
+            onDispose {
+                Cef.dispose()
+            }
         }
     }
 }

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/InitProgress.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/InitProgress.kt
@@ -1,0 +1,75 @@
+package com.multiplatform.webview.web
+
+interface InitProgress {
+
+    fun locating() { }
+
+    fun downloading(progress: Float) { }
+
+    fun extracting() { }
+
+    fun install() { }
+
+    fun initializing() { }
+
+    fun initialized() { }
+
+    class Builder {
+        private var locatingCallback: () -> Unit = { }
+        private var downloadingCallback: (Float) -> Unit = { }
+        private var extractingCallback: () -> Unit = { }
+        private var installCallback: () -> Unit = { }
+        private var initializingCallback: () -> Unit = { }
+        private var initializedCallback: () -> Unit = { }
+
+        fun onLocating(callback: () -> Unit) = apply {
+            locatingCallback = callback
+        }
+
+        fun onDownloading(callback: (progress: Float) -> Unit) = apply {
+            downloadingCallback = callback
+        }
+
+        fun onExtracting(callback: () -> Unit) = apply {
+            extractingCallback = callback
+        }
+
+        fun onInstall(callback: () -> Unit) = apply {
+            installCallback = callback
+        }
+
+        fun onInitializing(callback: () -> Unit) = apply {
+            initializingCallback = callback
+        }
+
+        fun onInitialized(callback: () -> Unit) = apply {
+            initializedCallback = callback
+        }
+
+        fun build(): InitProgress = object : InitProgress {
+            override fun locating() {
+                locatingCallback()
+            }
+
+            override fun downloading(progress: Float) {
+                downloadingCallback(progress)
+            }
+
+            override fun extracting() {
+                extractingCallback()
+            }
+
+            override fun install() {
+                installCallback()
+            }
+
+            override fun initializing() {
+                initializingCallback()
+            }
+
+            override fun initialized() {
+                initializedCallback()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added listener to handle CEF initialization progress.
Additionally the restart may not be required anymore (depending on wether CEF could be initialized after or not)

The listener is handy to keep track of the download progress for example.
Take a look at the updated Desktop example