### PR TITLE
feature: add set background color option for android client

### DIFF
--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.viewinterop.AndroidView
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import com.multiplatform.webview.util.KLogger
@@ -187,6 +188,7 @@ fun AccompanistWebView(
                             isAlgorithmicDarkeningAllowed = it.isAlgorithmicDarkeningAllowed
                         }
                         setSupportZoom(it.supportZoom)
+                        setBackgroundColor(it.backgroundColor.toArgb())
                         allowFileAccess = it.allowFileAccess
                         textZoom = it.textZoom
                         useWideViewPort = it.useWideViewPort

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -1,5 +1,7 @@
 package com.multiplatform.webview.setting
 
+import androidx.compose.ui.graphics.Color
+
 /**
  * Created By Kevin Zou On 2023/9/20
  */
@@ -175,6 +177,12 @@ sealed class PlatformWebSettings {
          * Default is [LayerType.HARDWARE]
          */
         var layerType: Int = LayerType.HARDWARE,
+        /**
+         * The background color of the WebView client. The default value is {@code Color.Transparent}.
+         *
+         * @param backgroundColor a color value
+         */
+        var backgroundColor: Color = Color.Transparent,
     ) : PlatformWebSettings() {
         object LayerType {
             const val NONE = 0


### PR DESCRIPTION
When using the android webview client there is a brief white flicker as content loads. This is especially noticeable when loading a webpage with a dark background onto a Composable with the same background. This PR adds the option to set the client background color and sets the default to Transparent. This removes the white flicker on startup but also gives the user the ability to override it if needed. 

Sample with flicker before changes: 
https://github.com/KevinnZou/compose-webview-multiplatform/assets/32306780/b049dada-03ff-4bc4-b404-e86379335edb

Sample without flicker after changes: 

https://github.com/KevinnZou/compose-webview-multiplatform/assets/32306780/baf52bde-2204-4c6b-bf98-d3169e68735c

Reproducible Code: 
```
val html =
        """
        <html>
        <head>
            <title>Flicker Sample: Blue</title>
            <style>
                body {
                    background-color: 0000FF; 
                    }
            </style>
        </head>
        <body>
            <h1>Flicker Sample</h1>
        </body>
        </html>
        """
@Composable
fun WebViewFlickerSample(){
    val webViewState = rememberWebViewStateWithHTMLData(html)
    Column(Modifier.fillMaxSize().background(Color.Blue)) {
        WebView(
            state = webViewState,
            modifier = Modifier.padding(16.dp).fillMaxSize(),
        )
    }
}
```
