### PR TITLE
bugfix: Use interaction not working when `captureBackpresses` is disabled on iOS

### DIFF
--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -78,7 +78,6 @@ fun IOSWebView(
                 frame = CGRectZero.readValue(),
                 configuration = config,
             ).apply {
-                userInteractionEnabled = captureBackPresses
                 allowsBackForwardNavigationGestures = captureBackPresses
                 customUserAgent = state.webSettings.customUserAgentString
                 this.addProgressObservers(


### PR DESCRIPTION
Even if the back navigation is disabled, we would still want to enable the user interaction, so that things like scroll can work.

fixes: #94 