### PR TITLE
add additional iOS platform settings

### DIFF
--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -211,7 +211,7 @@ sealed class PlatformWebSettings {
          *
          * @param underPageBackgroundColor a color value
          */
-        var underPageBackgroundColor: Color = Color.White,
+        var underPageBackgroundColor: Color? = null,
         /**
          * Whether the WebView bounces when scrolled past content bounds.
          * The default value is {@code true}.

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -207,7 +207,7 @@ sealed class PlatformWebSettings {
         var backgroundColor: Color? = null,
         /**
          * The background color shown when the WebView client scrolls past the bounds of the active page.
-         * The default value is {@code Color.White}.
+         * The default value is {@code null}. Will use WebSettings backgroundColor when null.
          *
          * @param underPageBackgroundColor a color value
          */

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -1,5 +1,7 @@
 package com.multiplatform.webview.setting
 
+import androidx.compose.ui.graphics.Color
+
 /**
  * Created By Kevin Zou On 2023/9/20
  */
@@ -195,5 +197,37 @@ sealed class PlatformWebSettings {
     /**
      * IOS web settings
      */
-    data object IOSWebSettings : PlatformWebSettings()
+    data class IOSWebSettings(
+        /**
+         * The background color of the WebView client. The default value is {@code null}.
+         * Will use WebSettings backgroundColor when null.
+         *
+         * @param backgroundColor a color value
+         */
+        var backgroundColor: Color? = null,
+        /**
+         * The background color shown when the WebView client scrolls past the bounds of the active page.
+         * The default value is {@code Color.White}.
+         *
+         * @param underPageBackgroundColor a color value
+         */
+        var underPageBackgroundColor: Color = Color.White,
+        /**
+         * Whether the WebView bounces when scrolled past content bounds.
+         * The default value is {@code true}.
+         */
+        var bounces: Boolean = true,
+        /**
+         * Whether horizontal and vertical scrolling is enabled. The default value is {@code true}.
+         */
+        var scrollEnabled: Boolean = true,
+        /**
+         * Whether the horizontal scroll indicator is visible. The default value is {@code true}.
+         */
+        var showHorizontalScrollIndicator: Boolean = true,
+        /**
+         * Whether the vertical scroll indicator is visible. The default value is {@code true}.
+         */
+        var showVerticalScrollIndicator: Boolean = true,
+    ) : PlatformWebSettings()
 }

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/WebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/WebSettings.kt
@@ -95,5 +95,5 @@ class WebSettings {
     /**
      * iOS platform specific settings
      */
-    val iOSWebSettings = PlatformWebSettings.IOSWebSettings
+    val iOSWebSettings = PlatformWebSettings.IOSWebSettings()
 }

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/util/Color.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/util/Color.kt
@@ -1,0 +1,13 @@
+package com.multiplatform.webview.util
+
+import androidx.compose.ui.graphics.Color
+import platform.UIKit.UIColor
+
+fun Color.toUIColor(): UIColor {
+    return UIColor(
+        red = red.toDouble(),
+        green = green.toDouble(),
+        blue = blue.toDouble(),
+        alpha = alpha.toDouble(),
+    )
+}

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -89,11 +89,11 @@ fun IOSWebView(
                 setOpaque(false)
                 state.webSettings.let {
                     val backgroundColor = (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
+                    val scrollViewColor = (it.iOSWebSettings.underPageBackgroundColor ?: it.backgroundColor).toUIColor()
                     setBackgroundColor(backgroundColor)
-                    scrollView.setBackgroundColor(backgroundColor)
+                    scrollView.setBackgroundColor(scrollViewColor)
                 }
                 state.webSettings.iOSWebSettings.let {
-                    underPageBackgroundColor = it.underPageBackgroundColor.toUIColor()
                     with(scrollView) {
                         bounces = it.bounces
                         scrollEnabled = it.scrollEnabled

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -6,11 +6,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.interop.UIKitView
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
+import com.multiplatform.webview.util.toUIColor
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGRectZero
 import platform.Foundation.setValue
-import platform.UIKit.UIColor
 import platform.WebKit.WKWebView
 import platform.WebKit.WKWebViewConfiguration
 import platform.WebKit.javaScriptEnabled
@@ -87,16 +87,20 @@ fun IOSWebView(
                 this.navigationDelegate = navigationDelegate
 
                 setOpaque(false)
-                val composeBackgroundColor = state.webSettings.backgroundColor
-                val backgroundColor =
-                    UIColor(
-                        red = composeBackgroundColor.red.toDouble(),
-                        green = composeBackgroundColor.green.toDouble(),
-                        blue = composeBackgroundColor.blue.toDouble(),
-                        alpha = composeBackgroundColor.alpha.toDouble(),
-                    )
-                setBackgroundColor(backgroundColor)
-                scrollView.setBackgroundColor(backgroundColor)
+                state.webSettings.let {
+                    val backgroundColor = (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
+                    setBackgroundColor(backgroundColor)
+                    scrollView.setBackgroundColor(backgroundColor)
+                }
+                state.webSettings.iOSWebSettings.let {
+                    underPageBackgroundColor = it.underPageBackgroundColor.toUIColor()
+                    with(scrollView) {
+                        bounces = it.bounces
+                        scrollEnabled = it.scrollEnabled
+                        showsHorizontalScrollIndicator = it.showHorizontalScrollIndicator
+                        showsVerticalScrollIndicator = it.showVerticalScrollIndicator
+                    }
+                }
                 onCreated()
             }.also {
                 val iosWebView = IOSWebView(it, scope, webViewJsBridge)


### PR DESCRIPTION
In this PR I have updated the IOSWebSettings object with common WKWebView settings. This allows for more customization of the client on the IOS platform.  

While the Android WebView client is capable of having a transparent background due to the [limitations of UIKitView](https://github.com/JetBrains/compose-multiplatform/issues/3154) IOS is not. As shown below. 

<img src="https://github.com/KevinnZou/compose-webview-multiplatform/assets/32306780/8a25b4b3-a623-4d9b-bcd4-29e6fc6aa41b" width="250">

<img src="https://github.com/KevinnZou/compose-webview-multiplatform/assets/32306780/6c3093de-f1b6-4cca-93dc-f927f11f8c57l" width="250">


```
val html =
    """
        <html>  
        <body>
            <h1>Transparent WebView</h1>
        </body>
        </html>
        """
@Composable
fun TransparentWebViewSample(){
    val webViewState = rememberWebViewStateWithHTMLData(html)
    webViewState.webSettings.backgroundColor = Color.Transparent
    val background = Brush.horizontalGradient(listOf(Color(0xff92ccdd), Color(0xffc7eff0)))
    Column(Modifier.fillMaxSize().background(background)) {
        WebView(
            state = webViewState,
            modifier = Modifier.padding(16.dp).fillMaxSize(),
        )
    }
}
```

In short, the UIKitView itself is drawn on top of a white background and this functionality is not able to be overridden*. This means when WebSettings backgroundColor is set to transparent the IOS Webview will instead show the UIKitView’s white background.  To mitigate this, I have added an IOSWebSettings specific nullable backgroundColor. This is helpful in the use case where the user would like Android and Desktop client to be transparent but would prefer to set IOS webview background color to the next best option. If this value is null it will instead use the WebSettings background color. 


*An alternative method is discussed in this kotlin [compose-ios thread](https://kotlinlang.slack.com/archives/C0346LWVBJ4/p1685005635951389). If the user implements a custom ComposeUIViewController it is possible to have a transparent UIKitView but it requires overriding internal compose multiplatform classes.
