### PR TITLE
fix(backgroundColor scrolling): ios add opaque param

### DIFF
--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -190,14 +190,15 @@ sealed class PlatformWebSettings {
     data class IOSWebSettings(
         /**
          * The ios default opaque display
-         * The default value is {@code true}.
+         * The default value is {@code false}.
+         * When Value is true will turn off these two properties:
+         * @param backgroundColor,@param underPageBackgroundColor
          */
-        var opaque: Boolean = true,
+        var opaque: Boolean = false,
         /**
          * The background color of the WebView client. The default value is {@code null}.
          * Will use WebSettings backgroundColor when null.
          *
-         * @param opaque need set into false
          * @param backgroundColor a color value
          */
         var backgroundColor: Color? = null,
@@ -205,7 +206,6 @@ sealed class PlatformWebSettings {
          * The background color shown when the WebView client scrolls past the bounds of the active page.
          * The default value is {@code null}. Will use WebSettings backgroundColor when null.
          *
-         * @param opaque need set into false
          * @param underPageBackgroundColor a color value
          */
         var underPageBackgroundColor: Color? = null,

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -189,9 +189,15 @@ sealed class PlatformWebSettings {
      */
     data class IOSWebSettings(
         /**
+         * The ios default opaque display
+         * The default value is {@code true}.
+         */
+        var opaque: Boolean = true,
+        /**
          * The background color of the WebView client. The default value is {@code null}.
          * Will use WebSettings backgroundColor when null.
          *
+         * @param opaque need set into false
          * @param backgroundColor a color value
          */
         var backgroundColor: Color? = null,
@@ -199,6 +205,7 @@ sealed class PlatformWebSettings {
          * The background color shown when the WebView client scrolls past the bounds of the active page.
          * The default value is {@code null}. Will use WebSettings backgroundColor when null.
          *
+         * @param opaque need set into false
          * @param underPageBackgroundColor a color value
          */
         var underPageBackgroundColor: Color? = null,

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -102,9 +102,9 @@ fun IOSWebView(
                         (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
                     val scrollViewColor =
                         (
-                             it.iOSWebSettings.underPageBackgroundColor
-                                 ?: it.backgroundColor
-                         ).toUIColor()
+                            it.iOSWebSettings.underPageBackgroundColor
+                                ?: it.backgroundColor
+                        ).toUIColor()
                     setOpaque(it.iOSWebSettings.opaque)
                     if (!it.iOSWebSettings.opaque) {
                         setBackgroundColor(backgroundColor)

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -101,10 +101,8 @@ fun IOSWebView(
                     val backgroundColor =
                         (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
                     val scrollViewColor =
-                        (
-                                it.iOSWebSettings.underPageBackgroundColor
-                                    ?: it.backgroundColor
-                                ).toUIColor()
+                        (it.iOSWebSettings.underPageBackgroundColor
+                            ?: it.backgroundColor).toUIColor()
                     setOpaque(it.iOSWebSettings.opaque)
                     if (!it.iOSWebSettings.opaque) {
                         setBackgroundColor(backgroundColor)

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -101,8 +101,10 @@ fun IOSWebView(
                     val backgroundColor =
                         (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
                     val scrollViewColor =
-                        (it.iOSWebSettings.underPageBackgroundColor
-                            ?: it.backgroundColor).toUIColor()
+                        (
+                             it.iOSWebSettings.underPageBackgroundColor
+                                 ?: it.backgroundColor
+                         ).toUIColor()
                     setOpaque(it.iOSWebSettings.opaque)
                     if (!it.iOSWebSettings.opaque) {
                         setBackgroundColor(backgroundColor)

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -97,7 +97,6 @@ fun IOSWebView(
                 )
                 this.navigationDelegate = navigationDelegate
 
-                setOpaque(false)
                 state.webSettings.let {
                     val backgroundColor =
                         (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
@@ -106,8 +105,11 @@ fun IOSWebView(
                             it.iOSWebSettings.underPageBackgroundColor
                                 ?: it.backgroundColor
                         ).toUIColor()
-                    setBackgroundColor(backgroundColor)
-                    scrollView.setBackgroundColor(scrollViewColor)
+                    setOpaque(it.iOSWebSettings.opaque)
+                    if (!it.iOSWebSettings.opaque){
+                        setBackgroundColor(backgroundColor)
+                        scrollView.setBackgroundColor(scrollViewColor)
+                    }
                     scrollView.pinchGestureRecognizer?.enabled = it.supportZoom
                 }
                 state.webSettings.iOSWebSettings.let {

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -102,11 +102,11 @@ fun IOSWebView(
                         (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
                     val scrollViewColor =
                         (
-                            it.iOSWebSettings.underPageBackgroundColor
-                                ?: it.backgroundColor
-                        ).toUIColor()
+                                it.iOSWebSettings.underPageBackgroundColor
+                                    ?: it.backgroundColor
+                                ).toUIColor()
                     setOpaque(it.iOSWebSettings.opaque)
-                    if (!it.iOSWebSettings.opaque){
+                    if (!it.iOSWebSettings.opaque) {
                         setBackgroundColor(backgroundColor)
                         scrollView.setBackgroundColor(scrollViewColor)
                     }


### PR DESCRIPTION
fix since 1.8.6 version issue that backgroundColor can scroll and status bar‘s backgroundColor is transparent, which add switch param opaque.