### PR TITLE
Expose several internal fields and add factory functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ The complete API of this library is as follows:
  * navigation from outside the composable.
  * @param onCreated Called when the WebView is first created.
  * @param onDispose Called when the WebView is destroyed.
+ * @param factory A function that creates a platform-specific WebView object.
  * @sample sample.BasicWebViewSample
  */
 @Composable
@@ -563,8 +564,10 @@ fun WebView(
     modifier: Modifier = Modifier,
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
-    onCreated: () -> Unit = {},
-    onDispose: () -> Unit = {},
+    webViewJsBridge: WebViewJsBridge? = null,
+    onCreated: (NativeWebView) -> Unit = {},
+    onDispose: (NativeWebView) -> Unit = {},
+    factory: ((WebViewFactoryParam) -> NativeWebView)? = null,
 )
 ```
 

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AndroidWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AndroidWebView.kt
@@ -12,11 +12,13 @@ import kotlinx.serialization.json.Json
  * Created By Kevin Zou On 2023/9/5
  */
 
+actual typealias NativeWebView = WebView
+
 /**
  * Android implementation of [IWebView]
  */
 class AndroidWebView(
-    private val webView: WebView,
+    override val webView: WebView,
     override val scope: CoroutineScope,
     override val webViewJsBridge: WebViewJsBridge?,
 ) : IWebView {

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
@@ -1,5 +1,6 @@
 package com.multiplatform.webview.web
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
@@ -16,6 +17,7 @@ actual fun ActualWebView(
     webViewJsBridge: WebViewJsBridge?,
     onCreated: (NativeWebView) -> Unit,
     onDispose: (NativeWebView) -> Unit,
+    factory: (WebViewFactoryParam) -> NativeWebView,
 ) {
     AccompanistWebView(
         state,
@@ -25,5 +27,12 @@ actual fun ActualWebView(
         webViewJsBridge,
         onCreated = onCreated,
         onDispose = onDispose,
+        factory = { factory(WebViewFactoryParam(it)) },
     )
 }
+
+/** Android WebView factory parameters: a context. */
+actual data class WebViewFactoryParam(val context: Context)
+
+/** Default WebView factory for Android. */
+actual fun defaultWebViewFactory(param: WebViewFactoryParam) = android.webkit.WebView(param.context)

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
@@ -14,8 +14,8 @@ actual fun ActualWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
-    onCreated: () -> Unit,
-    onDispose: () -> Unit,
+    onCreated: (NativeWebView) -> Unit,
+    onDispose: (NativeWebView) -> Unit,
 ) {
     AccompanistWebView(
         state,
@@ -23,7 +23,7 @@ actual fun ActualWebView(
         captureBackPresses,
         navigator,
         webViewJsBridge,
-        onCreated = { _ -> onCreated() },
-        onDispose = { _ -> onDispose() },
+        onCreated = onCreated,
+        onDispose = onDispose,
     )
 }

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/IWebView.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/IWebView.kt
@@ -10,10 +10,18 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
  * Created By Kevin Zou On 2023/9/5
  */
 
+expect class NativeWebView
+
 /**
  * Interface for WebView
  */
 interface IWebView {
+    /**
+     * The native web view instance. On Android, this is an instance of [android.webkit.WebView].
+     * On iOS, this is an instance of [WKWebView]. On desktop, this is an instance of [KCEFBrowser].
+     */
+    val webView: NativeWebView
+
     val scope: CoroutineScope
 
     val webViewJsBridge: WebViewJsBridge?

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
@@ -16,8 +16,43 @@ import kotlinx.coroutines.flow.merge
  */
 
 /**
+ * Provides a basic WebView composable.
+ * This version of the function is provided for backwards compatibility by using the older
+ * onCreated and onDispose callbacks and is missing the factory parameter.
  *
- * A wrapper around the Android View WebView to provide a basic WebView composable.
+ * @param state The webview state holder where the Uri to load is defined.
+ * @param modifier A compose modifier
+ * @param captureBackPresses Set to true to have this Composable capture back presses and navigate
+ * the WebView back.
+ * @param navigator An optional navigator object that can be used to control the WebView's
+ * navigation from outside the composable.
+ * @param onCreated Called when the WebView is first created.
+ * @param onDispose Called when the WebView is destroyed.
+ * @sample sample.BasicWebViewSample
+ */
+@Composable
+fun WebView(
+    state: WebViewState,
+    modifier: Modifier = Modifier,
+    captureBackPresses: Boolean = true,
+    navigator: WebViewNavigator = rememberWebViewNavigator(),
+    webViewJsBridge: WebViewJsBridge? = null,
+    onCreated: () -> Unit = {},
+    onDispose: () -> Unit = {},
+) {
+    WebView(
+        state = state,
+        modifier = modifier,
+        captureBackPresses = captureBackPresses,
+        navigator = navigator,
+        webViewJsBridge = webViewJsBridge,
+        onCreated = { _ -> onCreated() },
+        onDispose = { _ -> onDispose() },
+    )
+}
+
+/**
+ * Provides a basic WebView composable.
  *
  * @param state The webview state holder where the Uri to load is defined.
  * @param modifier A compose modifier

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
@@ -10,7 +10,6 @@ import com.multiplatform.webview.util.KLogger
 import com.multiplatform.webview.util.getPlatform
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.merge
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 
 /**
  * Created By Kevin Zou On 2023/8/31
@@ -30,7 +29,6 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
  * @param onDispose Called when the WebView is destroyed.
  * @sample sample.BasicWebViewSample
  */
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun WebView(
     state: WebViewState,
@@ -38,8 +36,8 @@ fun WebView(
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewJsBridge: WebViewJsBridge? = null,
-    onCreated: () -> Unit = {},
-    onDispose: () -> Unit = {},
+    onCreated: (NativeWebView) -> Unit = {},
+    onDispose: (NativeWebView) -> Unit = {},
 ) {
     val webView = state.webView
 
@@ -141,6 +139,6 @@ expect fun ActualWebView(
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewJsBridge: WebViewJsBridge? = null,
-    onCreated: () -> Unit = {},
-    onDispose: () -> Unit = {},
+    onCreated: (NativeWebView) -> Unit = {},
+    onDispose: (NativeWebView) -> Unit = {},
 )

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebViewState.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebViewState.kt
@@ -76,6 +76,12 @@ class WebViewState(webContent: WebContent) {
     internal var webView by mutableStateOf<IWebView?>(null)
 
     /**
+     * The native web view instance. On Android, this is an instance of [android.webkit.WebView].
+     * On iOS, this is an instance of [WKWebView]. On desktop, this is an instance of [KCEFBrowser].
+     */
+    val nativeWebView get() = webView?.webView ?: error("WebView is not initialized")
+
+    /**
      * The saved view state from when the view was destroyed last. To restore state,
      * use the navigator and only call loadUrl if the bundle is null.
      * See WebViewSaveStateSample.

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/DesktopWebView.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/DesktopWebView.kt
@@ -15,11 +15,13 @@ import org.cef.network.CefPostData
 import org.cef.network.CefPostDataElement
 import org.cef.network.CefRequest
 
+actual typealias NativeWebView = KCEFBrowser
+
 /**
  * Created By Kevin Zou On 2023/9/12
  */
 class DesktopWebView(
-    private val webView: KCEFBrowser,
+    override val webView: KCEFBrowser,
     override val scope: CoroutineScope,
     override val webViewJsBridge: WebViewJsBridge?,
 ) : IWebView {

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebView.desktop.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebView.desktop.kt
@@ -20,8 +20,8 @@ actual fun ActualWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
-    onCreated: () -> Unit,
-    onDispose: () -> Unit,
+    onCreated: (NativeWebView) -> Unit,
+    onDispose: (NativeWebView) -> Unit,
 ) {
     DesktopWebView(
         state,
@@ -43,8 +43,8 @@ fun DesktopWebView(
     modifier: Modifier,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
-    onCreated: () -> Unit,
-    onDispose: () -> Unit,
+    onCreated: (NativeWebView) -> Unit,
+    onDispose: (NativeWebView) -> Unit,
 ) {
     val currentOnDispose by rememberUpdatedState(onDispose)
     val client =
@@ -132,7 +132,7 @@ fun DesktopWebView(
     browser?.let {
         SwingPanel(
             factory = {
-                onCreated()
+                onCreated(it)
                 state.webView = desktopWebView
                 webViewJsBridge?.webView = desktopWebView
                 browser.apply {
@@ -149,7 +149,7 @@ fun DesktopWebView(
     DisposableEffect(Unit) {
         onDispose {
             client?.dispose()
-            currentOnDispose()
+            browser?.let { currentOnDispose(it) }
         }
     }
 }

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebView.desktop.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebView.desktop.kt
@@ -58,17 +58,33 @@ actual class WebViewFactoryParam(
 actual fun defaultWebViewFactory(param: WebViewFactoryParam): NativeWebView =
     when (val content = param.state.content) {
         is WebContent.Url ->
-            param.client.createBrowser(content.url,
-                param.rendering, param.transparent, param.requestContext)
+            param.client.createBrowser(
+                content.url,
+                param.rendering,
+                param.transparent,
+                param.requestContext,
+            )
         is WebContent.Data ->
-            param.client.createBrowserWithHtml(content.data,
-                content.baseUrl ?: KCEFBrowser.BLANK_URI, param.rendering, param.transparent)
+            param.client.createBrowserWithHtml(
+                content.data,
+                content.baseUrl ?: KCEFBrowser.BLANK_URI,
+                param.rendering,
+                param.transparent,
+            )
         is WebContent.File ->
-            param.client.createBrowserWithHtml(param.fileContent,
-                KCEFBrowser.BLANK_URI, param.rendering, param.transparent)
+            param.client.createBrowserWithHtml(
+                param.fileContent,
+                KCEFBrowser.BLANK_URI,
+                param.rendering,
+                param.transparent,
+            )
         else ->
-            param.client.createBrowser(KCEFBrowser.BLANK_URI,
-                param.rendering, param.transparent, param.requestContext)
+            param.client.createBrowser(
+                KCEFBrowser.BLANK_URI,
+                param.rendering,
+                param.transparent,
+                param.requestContext,
+            )
     }
 
 /**
@@ -109,12 +125,14 @@ fun DesktopWebView(
             }
     }
 
-    val browser: KCEFBrowser? = remember(client, state.webSettings, fileContent) {
-        client?.let { factory(WebViewFactoryParam(state, client, fileContent)) }
-    }
-    val desktopWebView: DesktopWebView? = remember(browser) {
-        browser?.let { DesktopWebView(browser, scope, webViewJsBridge) }
-    }
+    val browser: KCEFBrowser? =
+        remember(client, state.webSettings, fileContent) {
+            client?.let { factory(WebViewFactoryParam(state, client, fileContent)) }
+        }
+    val desktopWebView: DesktopWebView? =
+        remember(browser) {
+            browser?.let { DesktopWebView(browser, scope, webViewJsBridge) }
+        }
 
     browser?.let {
         SwingPanel(

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -46,9 +46,7 @@ actual data class WebViewFactoryParam(val config: WKWebViewConfiguration)
 
 /** Default WebView factory for iOS. */
 @OptIn(ExperimentalForeignApi::class)
-actual fun defaultWebViewFactory(param: WebViewFactoryParam) = WKWebView(
-    frame = CGRectZero.readValue(), configuration = param.config,
-)
+actual fun defaultWebViewFactory(param: WebViewFactoryParam) = WKWebView(frame = CGRectZero.readValue(), configuration = param.config)
 
 /**
  * iOS WebView implementation.

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -25,8 +25,8 @@ actual fun ActualWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
-    onCreated: () -> Unit,
-    onDispose: () -> Unit,
+    onCreated: (NativeWebView) -> Unit,
+    onDispose: (NativeWebView) -> Unit,
 ) {
     IOSWebView(
         state = state,
@@ -50,8 +50,8 @@ fun IOSWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
-    onCreated: () -> Unit,
-    onDispose: () -> Unit,
+    onCreated: (NativeWebView) -> Unit,
+    onDispose: (NativeWebView) -> Unit,
 ) {
     val observer =
         remember {
@@ -85,8 +85,8 @@ fun IOSWebView(
             WKWebView(
                 frame = CGRectZero.readValue(),
                 configuration = config,
-            ).apply {
-                onCreated()
+            )).apply {
+                onCreated(this)
                 state.viewState?.let {
                     this.interactionState = it
                 }
@@ -133,7 +133,7 @@ fun IOSWebView(
                 observer = observer,
             )
             it.navigationDelegate = null
-            onDispose()
+            onDispose(it)
         },
     )
 }


### PR DESCRIPTION
This works to address #181.

Changes:
- [x] An `expect`/`actual` set of typealiases is made for each platform defining a `NativeWebView` as either `android.webkit.WebView`, `WKWebView`, or `KCEFBrowser`.
- [x] The `webView` field in each platform's `IWebView` is publicly exposed as a `NativeWebView`
- [x] `WebViewState` has a new field `nativeWebView` which publicly exposes this in the state without exposing anything else
- [x] Make `onCreate` and `onDispose` callbacks of `WebView()` composable take a `NativeWebView` argument
  - Minor backwards incompatibility is introduced with this if function references are passed as these callbacks instead of lambda/anonymous functions (which will automatically adapt to and ignore the added argument). Old code may need to place `{ }` around the callback call to make it work again.
- [x] Add a `factory` function to the `WebView()` composable that allows the caller to specify how web view objects should be created.
  - Minor backwards incompatibility in that if there is any code that assumes the final argument of the `WebView()` composable is the `onDispose` callback and moved the lambda out of the paratheses will have to move it into the paratheses.

Both of the minor issues could be mitigated with creating a wrapper function that matches the old version. If you want this added, I can add it to the PR.