### PR TITLE
Feature/support android file choose

### DIFF
--- a/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/FileChooseWebViewSample.kt
+++ b/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/FileChooseWebViewSample.kt
@@ -1,0 +1,68 @@
+package com.kevinnzou.sample
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import com.multiplatform.webview.util.KLogSeverity
+import com.multiplatform.webview.web.WebView
+import com.multiplatform.webview.web.rememberWebViewNavigator
+import com.multiplatform.webview.web.rememberWebViewStateWithHTMLFile
+
+/**
+ * Created By briandr97 2024/8/8
+ *
+ * Basic Sample for choose file in webview
+ */
+@Composable
+internal fun FileChooseWebViewSample(navHostController: NavHostController? = null) {
+    val webViewState = rememberWebViewStateWithHTMLFile(fileName = "fileChoose.html")
+    val webViewNavigator = rememberWebViewNavigator()
+    LaunchedEffect(Unit) {
+        webViewState.webSettings.apply {
+            zoomLevel = 1.0
+            logSeverity = KLogSeverity.Debug
+            androidWebSettings.apply {
+                isAlgorithmicDarkeningAllowed = true
+                safeBrowsingEnabled = true
+                allowFileAccess = false
+            }
+        }
+    }
+    MaterialTheme {
+        Column {
+            TopAppBar(
+                title = { Text(text = "Html Sample") },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        navHostController?.popBackStack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+
+            Box(Modifier.fillMaxSize()) {
+                WebView(
+                    state = webViewState,
+                    modifier = Modifier.fillMaxSize(),
+                    captureBackPresses = false,
+                    navigator = webViewNavigator,
+                )
+            }
+        }
+    }
+}

--- a/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/WebViewApp.kt
+++ b/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/WebViewApp.kt
@@ -50,6 +50,9 @@ internal fun WebViewApp() {
         composable("intercept") {
             InterceptRequestSample(controller)
         }
+        composable("file") {
+            FileChooseWebViewSample(controller)
+        }
     }
 }
 
@@ -82,6 +85,12 @@ fun MainScreen(controller: NavController) {
             controller.navigate("intercept")
         }) {
             Text("Intercept Request Sample", fontSize = 18.sp)
+        }
+        Spacer(modifier = Modifier.height(20.dp))
+        Button(onClick = {
+            controller.navigate("file")
+        }) {
+            Text("File Choose Sample", fontSize = 18.sp)
         }
     }
 }

--- a/sample/shared/src/commonMain/resources/assets/fileChoose.html
+++ b/sample/shared/src/commonMain/resources/assets/fileChoose.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+    <header>
+        <meta name='viewport'
+              content='width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'>
+    </header>
+    <link rel="stylesheet" type="text/css" href="styles.css">
+    <title>Compose WebView Multiplatform</title>
+</head>
+<body>
+<h1>Compose WebView Multiplatform</h1>
+<div>
+    <text>image: </text>
+    <input type="file" multiple name="image" id="imageChoose" accept="image/*">
+</div>
+<div>
+    <text>video: </text>
+    <input type="file" multiple name="video" id="videoChoose" accept="video/*">
+</div>
+<div>
+    <text>audio: </text>
+    <input type="file" multiple name="audio" id="audioChoose" accept="audio/*">
+</div>
+</body>
+</html>

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/FileChoosableWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/FileChoosableWebView.kt
@@ -1,0 +1,109 @@
+package com.multiplatform.webview.web
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient.FileChooserParams
+import android.webkit.WebView
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.multiplatform.webview.jsbridge.WebViewJsBridge
+
+@Composable
+fun FileChoosableWebView(
+    state: WebViewState,
+    modifier: Modifier,
+    captureBackPresses: Boolean,
+    navigator: WebViewNavigator,
+    webViewJsBridge: WebViewJsBridge?,
+    onCreated: (NativeWebView) -> Unit,
+    onDispose: (NativeWebView) -> Unit,
+    factory: (WebViewFactoryParam) -> NativeWebView,
+) {
+    var fileChooserIntent by remember { mutableStateOf<Intent?>(null) }
+
+    val webViewChromeClient =
+        remember {
+            FileChoosableWebChromeClient(onShowFilePicker = { fileChooserIntent = it })
+        }
+
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+        ) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val data = FileChooserParams.parseResult(result.resultCode, result.data)
+                if (data == null) {
+                    webViewChromeClient.cancelFileChooser()
+                } else {
+                    webViewChromeClient.onReceiveFiles(data)
+                }
+            } else {
+                webViewChromeClient.cancelFileChooser()
+            }
+        }
+
+    LaunchedEffect(key1 = fileChooserIntent) {
+        if (fileChooserIntent != null) {
+            try {
+                launcher.launch(fileChooserIntent)
+            } catch (e: ActivityNotFoundException) {
+                webViewChromeClient.cancelFileChooser()
+            }
+        }
+    }
+
+    AccompanistWebView(
+        state,
+        modifier,
+        captureBackPresses,
+        navigator,
+        webViewJsBridge,
+        onCreated = onCreated,
+        onDispose = onDispose,
+        factory = { factory(WebViewFactoryParam(it)) },
+        chromeClient = webViewChromeClient,
+    )
+}
+
+class FileChoosableWebChromeClient(
+    private val onShowFilePicker: (Intent) -> Unit,
+) : AccompanistWebChromeClient() {
+    private var filePathCallback: ValueCallback<Array<Uri>>? = null
+
+    override fun onShowFileChooser(
+        webView: WebView?,
+        filePathCallback: ValueCallback<Array<Uri>>?,
+        fileChooserParams: FileChooserParams?,
+    ): Boolean {
+        this.filePathCallback = filePathCallback
+        val filePickerIntent = fileChooserParams?.createIntent()
+
+        if (filePickerIntent == null) {
+            cancelFileChooser()
+        } else {
+            onShowFilePicker(filePickerIntent)
+        }
+        return true
+    }
+
+    fun onReceiveFiles(uris: Array<Uri>) {
+        filePathCallback?.onReceiveValue(uris)
+        filePathCallback = null
+    }
+
+    fun cancelFileChooser() {
+        filePathCallback?.onReceiveValue(null)
+        filePathCallback = null
+    }
+}

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
@@ -19,7 +19,7 @@ actual fun ActualWebView(
     onDispose: (NativeWebView) -> Unit,
     factory: (WebViewFactoryParam) -> NativeWebView,
 ) {
-    AccompanistWebView(
+    FileChoosableWebView(
         state,
         modifier,
         captureBackPresses,
@@ -27,7 +27,7 @@ actual fun ActualWebView(
         webViewJsBridge,
         onCreated = onCreated,
         onDispose = onDispose,
-        factory = { factory(WebViewFactoryParam(it)) },
+        factory = factory,
     )
 }
 


### PR DESCRIPTION
Hi @KevinnZou thank you for creating this library. I'm using this in Compose Multiplatform and have encountered a problem.
In my service, I need to get some images from device. And on Android, the file chooser isn't opened in the WebView unless we implement onShowFileChooser. So I added code to override onShowFileChooser in the WebChromeClient. I'm on a deadline, so I was wondering if you could please reflect this change?

### Key Changes:
- override WebChromeClient's onShowFileChooser on Android side.
- add sample for choose files

### Result:
<img src="https://github.com/user-attachments/assets/fa8da049-40b6-40ad-a7f1-3cfc9a04a1ed" width="24%">
<img src="https://github.com/user-attachments/assets/b3d5eebf-fc1d-48b1-9055-96719fd4b82d" width="24%">
<img src="https://github.com/user-attachments/assets/26aeeaee-e1a1-4100-ac7b-f72c9d089139" width="24%">
<img src="https://github.com/user-attachments/assets/5fb4d1c0-08bc-4c15-914c-853f8a606daa" width="24%">



