### PR TITLE
handle PermissionRequests in the WebChromeClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,37 @@ Note that the HTML file should be put in the `resources/assets` folder of the sh
 It also supports external resources such as images, CSS, and JavaScript files on Android and iOS.
 Desktop support is coming soon.
 
+## Handling permission requests on Android
+
+There are 4 types of permissions that can be requested by the WebView on Android: 
+
+- RESOURCE_PROTECTED_MEDIA_ID
+- RESOURCE_MIDI_SYSEX
+- RESOURCE_AUDIO_CAPTURE
+- RESOURCE_VIDEO_CAPTURE
+
+`RESOURCE_PROTECTED_MEDIA_ID` and `RESOURCE_MIDI_SYSEX` are special ones, because they don't have a
+native Android counterpart, so it's not possible to request a permission from the user to grant
+them transitively. Therefore, you configure the WebView to grant these permissions automatically, 
+by setting the respective properties under `AndroidWebSettings` to true:
+
+```kotlin
+webViewState.webSettings.apply {
+        // ...
+        androidWebSettings.apply {
+            // Grants RESOURCE_PROTECTED_MEDIA_ID permission, default false
+            allowProtectedMedia = true
+            // Grants RESOURCE_MIDI_SYSEX permission, default false
+            allowMidiSysexMessages = true
+        }
+        // ...
+    }
+```
+
+`RESOURCE_AUDIO_CAPTURE` and `RESOURCE_VIDEO_CAPTURE` are also handled internally by the WebView,
+but you need to make sure to explicitly ask for these permissions in your app. If user grants them,
+the WebView will be able to use them without any additional configuration.
+
 ## API
 
 The complete API of this library is as follows:

--- a/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/DRMVideoSample.kt
+++ b/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/DRMVideoSample.kt
@@ -1,0 +1,73 @@
+package com.kevinnzou.sample
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import com.multiplatform.webview.util.KLogSeverity
+import com.multiplatform.webview.web.WebView
+import com.multiplatform.webview.web.rememberWebViewNavigator
+import com.multiplatform.webview.web.rememberWebViewState
+
+/**
+ * Created By Adam Kobor on 2024/9/9
+ *
+ * Sample for DRM protected video handling in WebView.
+ * `allowProtectedMedia` is set to true in the WebView settings, so EME APIs can be used to play DRM
+ * protected content.
+ */
+@Composable
+internal fun DRMVideoSample(navHostController: NavHostController? = null) {
+    val url = "https://bitmovin.com/demos/drm/"
+    val state = rememberWebViewState(url = url)
+    DisposableEffect(Unit) {
+        state.webSettings.apply {
+            logSeverity = KLogSeverity.Debug
+            customUserAgentString =
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/625.20 (KHTML, like Gecko) Version/14.3.43 Safari/625.20"
+            androidWebSettings.allowProtectedMedia = true
+        }
+
+        onDispose { }
+    }
+    val navigator = rememberWebViewNavigator()
+
+    MaterialTheme {
+        Column {
+            TopAppBar(
+                title = { Text(text = "DRM Video Sample") },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        if (navigator.canGoBack) {
+                            navigator.navigateBack()
+                        } else {
+                            navHostController?.popBackStack()
+                        }
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+
+            WebView(
+                state = state,
+                modifier =
+                Modifier
+                    .fillMaxSize(),
+                navigator = navigator,
+            )
+        }
+    }
+}

--- a/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/DRMVideoSample.kt
+++ b/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/DRMVideoSample.kt
@@ -63,9 +63,7 @@ internal fun DRMVideoSample(navHostController: NavHostController? = null) {
 
             WebView(
                 state = state,
-                modifier =
-                Modifier
-                    .fillMaxSize(),
+                modifier = Modifier.fillMaxSize(),
                 navigator = navigator,
             )
         }

--- a/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/MidiSample.kt
+++ b/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/MidiSample.kt
@@ -63,9 +63,7 @@ internal fun MidiSample(navHostController: NavHostController? = null) {
 
             WebView(
                 state = state,
-                modifier =
-                Modifier
-                    .fillMaxSize(),
+                modifier = Modifier.fillMaxSize(),
                 navigator = navigator,
             )
         }

--- a/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/MidiSample.kt
+++ b/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/MidiSample.kt
@@ -1,0 +1,73 @@
+package com.kevinnzou.sample
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import com.multiplatform.webview.util.KLogSeverity
+import com.multiplatform.webview.web.WebView
+import com.multiplatform.webview.web.rememberWebViewNavigator
+import com.multiplatform.webview.web.rememberWebViewState
+
+/**
+ * Created By Adam Kobor On 2024/9/9
+ *
+ * Sample for MIDI SysEx handling in WebView.
+ * `allowMidiSysexMessages` is set to true in the WebView settings, so MIDI SysEx messages can be
+ * sent and received.
+ */
+@Composable
+internal fun MidiSample(navHostController: NavHostController? = null) {
+    val url = "https://versioduo.com/webmidi-test/"
+    val state = rememberWebViewState(url = url)
+    DisposableEffect(Unit) {
+        state.webSettings.apply {
+            logSeverity = KLogSeverity.Debug
+            customUserAgentString =
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/625.20 (KHTML, like Gecko) Version/14.3.43 Safari/625.20"
+            androidWebSettings.allowMidiSysexMessages = true
+        }
+
+        onDispose { }
+    }
+    val navigator = rememberWebViewNavigator()
+
+    MaterialTheme {
+        Column {
+            TopAppBar(
+                title = { Text(text = "Midi SysEx Sample") },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        if (navigator.canGoBack) {
+                            navigator.navigateBack()
+                        } else {
+                            navHostController?.popBackStack()
+                        }
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+
+            WebView(
+                state = state,
+                modifier =
+                Modifier
+                    .fillMaxSize(),
+                navigator = navigator,
+            )
+        }
+    }
+}

--- a/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/WebViewApp.kt
+++ b/sample/shared/src/commonMain/kotlin/com/kevinnzou/sample/WebViewApp.kt
@@ -50,6 +50,12 @@ internal fun WebViewApp() {
         composable("intercept") {
             InterceptRequestSample(controller)
         }
+        composable("drm") {
+            DRMVideoSample(controller)
+        }
+        composable("midi") {
+            MidiSample(controller)
+        }
     }
 }
 
@@ -82,6 +88,18 @@ fun MainScreen(controller: NavController) {
             controller.navigate("intercept")
         }) {
             Text("Intercept Request Sample", fontSize = 18.sp)
+        }
+        Spacer(modifier = Modifier.height(20.dp))
+        Button(onClick = {
+            controller.navigate("drm")
+        }) {
+            Text("DRM Video Sample", fontSize = 18.sp)
+        }
+        Spacer(modifier = Modifier.height(20.dp))
+        Button(onClick = {
+            controller.navigate("midi")
+        }) {
+            Text("Midi SysEx Sample", fontSize = 18.sp)
         }
     }
 }

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -167,6 +167,19 @@ sealed class PlatformWebSettings {
          */
         var mediaPlaybackRequiresUserGesture: Boolean = true,
         /**
+         * Controls whether the `RESOURCE_PROTECTED_MEDIA_ID` permission requests should be
+         * automatically granted or not. Necessary to be able to play back DRM protected media
+         * inside the WebView.
+         * The default is {@code false}.
+         */
+        var allowProtectedMedia: Boolean = false,
+        /**
+         * Controls whether the `RESOURCE_MIDI_SYSEX` permission requests should be automatically
+         * granted or not. The resource will allow sysex messages to be sent to or received from MIDI
+         * devices. Available on API level 21 and above.
+         */
+        var allowMidiSysexMessages: Boolean = false,
+        /**
          * The Layer Type of the WebView.
          * Default is [LayerType.HARDWARE]
          */


### PR DESCRIPTION
The idea behind this PR is to be capable of handling permission requests coming from the webview on Android. These are vital, if you would like to play DRM protected content inside of it, for example.
The requested resources could be divided into two different groups: the ones where we have a native Android permission as a counterpart, and the ones where we don't. 
Where we don't have counterparts (midi sysex messages + protected media), we can use the newly introduced configuration properties inside `AndroidWebSettings` to automatically grant or deny the requested resources. On the other hand, where we have a counterpart for the requested resource, we check if the desired permission is already granted and if so, then we grant the requested resource too. 

What do you think @KevinnZou, would it make sense to have a dedicated section about this new functionality in the README?