### PR TITLE
handle null value of targetFrame in iOS interception logic

### DIFF
--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WKNavigationDelegate.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WKNavigationDelegate.kt
@@ -123,7 +123,7 @@ class WKNavigationDelegate(
         }
         if (url != null && !isRedirect &&
             navigator.requestInterceptor != null &&
-            decidePolicyForNavigationAction.targetFrame?.mainFrame == true
+            decidePolicyForNavigationAction.targetFrame?.mainFrame != false
         ) {
             navigator.requestInterceptor.apply {
                 val request = decidePolicyForNavigationAction.request


### PR DESCRIPTION
see https://github.com/KevinnZou/compose-webview-multiplatform/issues/221 and this answer here: https://stackoverflow.com/a/27391215

The `targetFrame` is null for target="_blank" links in the WKWebView, so these wouldn't count as navigation events (i.e. it won't be possible to intercept them)