### PR TITLE
Set `interactionMode` to `NonCooperative` in `IOSWebView`

### DIFF
--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -3,7 +3,9 @@ package com.multiplatform.webview.web
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
@@ -52,7 +54,7 @@ actual fun defaultWebViewFactory(param: WebViewFactoryParam) = WKWebView(frame =
 /**
  * iOS WebView implementation.
  */
-@OptIn(ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun IOSWebView(
     state: WebViewState,
@@ -145,7 +147,7 @@ fun IOSWebView(
         },
         properties =
             UIKitInteropProperties(
-                isInteractive = true,
+                interactionMode = UIKitInteropInteractionMode.NonCooperative,
                 isNativeAccessibilityEnabled = true,
             ),
     )


### PR DESCRIPTION
This will ensure that touch interactions are not processed by the Compose UI and passed down to the interop view.

fixes: #219 #228