### PR TITLE
IOS: fixing authorization on load local files

### DIFF
--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/IOSWebView.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/IOSWebView.kt
@@ -85,9 +85,10 @@ class IOSWebView(
     }
 
     override suspend fun loadHtmlFile(fileName: String) {
-        val res = NSBundle.mainBundle.resourcePath + "/compose-resources/assets/" + fileName
-        val url = NSURL.fileURLWithPath(res)
-        webView.loadFileURL(url, url)
+        val baseDir = NSBundle.mainBundle.resourcePath + "/compose-resources/assets/"
+        val fileToLoad = NSURL.fileURLWithPath(baseDir + fileName)
+        val fromDirectory = NSURL.fileURLWithPath(baseDir)
+        webView.loadFileURL(fileToLoad, fromDirectory)
     }
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)


### PR DESCRIPTION
#230

Fixing issue when load complex html.

You can try with this following html/js file

[Archive.zip](https://github.com/user-attachments/files/17161348/Archive.zip)
