### PR TITLE
provide information about the frame in WebViewError

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class WebViewState(webContent: WebContent) {
     /**
      * A list for errors captured in the last load. Reset when a new page is loaded.
      * Errors could be from any resource (iframe, image, etc.), not just for the main page.
-     * For more fine grained control use the OnError callback of the WebView.
+     * To filter for only main frame errors, use [WebViewError.isFromMainFrame].
      */
     val errorsForCurrentRequest: SnapshotStateList<WebViewError> = mutableStateListOf()
 

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
@@ -324,8 +324,9 @@ open class AccompanistWebViewClient : WebViewClient() {
         if (error != null) {
             state.errorsForCurrentRequest.add(
                 WebViewError(
-                    error.errorCode,
-                    error.description.toString(),
+                    code = error.errorCode,
+                    description = error.description.toString(),
+                    isFromMainFrame = request?.isForMainFrame ?: false,
                 ),
             )
         }

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebViewError.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebViewError.kt
@@ -19,4 +19,8 @@ data class WebViewError(
      * The error that was reported.
      */
     val description: String,
+    /**
+     * Is the error related to a request from the main frame?
+     */
+    val isFromMainFrame: Boolean,
 )

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebViewState.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebViewState.kt
@@ -59,7 +59,7 @@ class WebViewState(webContent: WebContent) {
     /**
      * A list for errors captured in the last load. Reset when a new page is loaded.
      * Errors could be from any resource (iframe, image, etc.), not just for the main page.
-     * For more fine grained control use the OnError callback of the WebView.
+     * To filter for only main frame errors, use [WebViewError.isFromMainFrame].
      */
     val errorsForCurrentRequest: SnapshotStateList<WebViewError> = mutableStateListOf()
 

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebEngineExt.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebEngineExt.kt
@@ -153,6 +153,7 @@ internal fun CefBrowser.addLoadListener(
                     WebViewError(
                         code = errorCode?.code ?: 404,
                         description = "Failed to load url: ${failedUrl}\n$errorText",
+                        isFromMainFrame = frame?.isMain ?: false,
                     ),
                 )
             }

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WKNavigationDelegate.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WKNavigationDelegate.kt
@@ -103,8 +103,10 @@ class WKNavigationDelegate(
         }
         state.errorsForCurrentRequest.add(
             WebViewError(
-                withError.code.toInt(),
-                withError.localizedDescription,
+                code = withError.code.toInt(),
+                description = withError.localizedDescription,
+                // on iOS all errors are from the main frame
+                isFromMainFrame = true,
             ),
         )
         KLogger.e {


### PR DESCRIPTION
it's useful to be able to react only on errors that are related to the main frame (and are probably result of a navigation).
on iOS it was inconsistent anyway, because only the navigation related requests propagated an error