### PR TITLE
video playback improvements

### DIFF
--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
@@ -491,6 +491,8 @@ open class AccompanistWebChromeClient : WebChromeClient() {
     override fun getDefaultVideoPoster(): Bitmap? {
         return if (state.webSettings.androidWebSettings.hideDefaultVideoPoster) {
             Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
-        } else super.getDefaultVideoPoster()
+        } else {
+            super.getDefaultVideoPoster()
+        }
     }
 }

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AccompanistWebView.kt
@@ -487,4 +487,10 @@ open class AccompanistWebChromeClient : WebChromeClient() {
             KLogger.d { "onPermissionRequest denied permissions: ${request.resources}" }
         }
     }
+
+    override fun getDefaultVideoPoster(): Bitmap? {
+        return if (state.webSettings.androidWebSettings.hideDefaultVideoPoster) {
+            Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
+        } else super.getDefaultVideoPoster()
+    }
 }

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -180,6 +180,10 @@ sealed class PlatformWebSettings {
          */
         var allowMidiSysexMessages: Boolean = false,
         /**
+         * Controls whether the default video poster (a gray, pixelated play button) should be hidden.
+         */
+        var hideDefaultVideoPoster: Boolean = false,
+        /**
          * The Layer Type of the WebView.
          * Default is [LayerType.HARDWARE]
          */

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/setting/PlatformWebSettings.kt
@@ -243,5 +243,9 @@ sealed class PlatformWebSettings {
          * Whether the vertical scroll indicator is visible. The default value is {@code true}.
          */
         var showVerticalScrollIndicator: Boolean = true,
+        /**
+         * Whether a user gesture is required to play media. The default is {@code true}.
+         */
+        var mediaPlaybackRequiresUserGesture: Boolean = true,
     ) : PlatformWebSettings()
 }

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -89,7 +89,9 @@ fun IOSWebView(
                     mediaTypesRequiringUserActionForPlayback =
                         if (state.webSettings.iOSWebSettings.mediaPlaybackRequiresUserGesture) {
                             WKAudiovisualMediaTypeAll
-                        } else WKAudiovisualMediaTypeNone
+                        } else {
+                            WKAudiovisualMediaTypeNone
+                        }
                     defaultWebpagePreferences.allowsContentJavaScript =
                         state.webSettings.isJavaScriptEnabled
                     preferences.apply {

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -14,6 +14,8 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGRectZero
 import platform.Foundation.setValue
+import platform.WebKit.WKAudiovisualMediaTypeAll
+import platform.WebKit.WKAudiovisualMediaTypeNone
 import platform.WebKit.WKWebView
 import platform.WebKit.WKWebViewConfiguration
 import platform.WebKit.javaScriptEnabled
@@ -84,6 +86,10 @@ fun IOSWebView(
             val config =
                 WKWebViewConfiguration().apply {
                     allowsInlineMediaPlayback = true
+                    mediaTypesRequiringUserActionForPlayback =
+                        if (state.webSettings.iOSWebSettings.mediaPlaybackRequiresUserGesture) {
+                            WKAudiovisualMediaTypeAll
+                        } else WKAudiovisualMediaTypeNone
                     defaultWebpagePreferences.allowsContentJavaScript =
                         state.webSettings.isJavaScriptEnabled
                     preferences.apply {


### PR DESCRIPTION
Hiding the default video poster on Android: this is an ugly, pixelated gray play icon by default, with the new property it's possible to completely hide it.

iOS auto playback: on Android we already had a similar property, and it's also possible on iOS to influence this behaviour. Effect is identical on both platforms.