### PR TITLE
Update ReadMe for JDK 17 desktop

### DIFF
--- a/README.desktop.md
+++ b/README.desktop.md
@@ -20,11 +20,19 @@ fun main() = application {
         var restartRequired by remember { mutableStateOf(false) }
         var downloading by remember { mutableStateOf(0F) }
         var initialized by remember { mutableStateOf(false) }
+        val download: Download = remember { Builder().github().build() }
 
         LaunchedEffect(Unit) {
             withContext(Dispatchers.IO) {
                 KCEF.init(builder = {
                     installDir(File("kcef-bundle"))
+                    
+                    /*
+                      Add this code when using JDK 17.
+                      Builder().github {
+                          release("jbr-release-17.0.10b1087.23")
+                      }.buffer(download.bufferSize).build()
+                     */
                     progress {
                         onDownloading {
                             downloading = max(it, 0F)


### PR DESCRIPTION
I've added instructions for using JDK 17 on desktop environments.
Since the release method has been deprecated, I've provided an alternative solution.

According : #134