### PR TITLE
Fix: Conditionally set inspectable property on iOS

### DIFF
--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -133,9 +133,9 @@ fun IOSWebView(
                             (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
                         val scrollViewColor =
                             (
-                                it.iOSWebSettings.underPageBackgroundColor
-                                    ?: it.backgroundColor
-                            ).toUIColor()
+                                    it.iOSWebSettings.underPageBackgroundColor
+                                        ?: it.backgroundColor
+                                    ).toUIColor()
                         setOpaque(it.iOSWebSettings.opaque)
                         if (!it.iOSWebSettings.opaque) {
                             setBackgroundColor(backgroundColor)
@@ -159,11 +159,12 @@ fun IOSWebView(
                      * Enabling this allows Safari Web Inspector to debug the content of the WebView.
                      * The value is determined by `state.webSettings.iOSWebSettings.isInspectable`.
                      */
-                    val minSetInspectableVersion = cValue<NSOperatingSystemVersion> {
-                        majorVersion = 16
-                        minorVersion = 4
-                        patchVersion = 0
-                    }
+                    val minSetInspectableVersion =
+                        cValue<NSOperatingSystemVersion> {
+                            majorVersion = 16
+                            minorVersion = 4
+                            patchVersion = 0
+                        }
                     if (NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion(minSetInspectableVersion)) {
                         this.setInspectable(state.webSettings.iOSWebSettings.isInspectable)
                     }

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -133,9 +133,9 @@ fun IOSWebView(
                             (it.iOSWebSettings.backgroundColor ?: it.backgroundColor).toUIColor()
                         val scrollViewColor =
                             (
-                                    it.iOSWebSettings.underPageBackgroundColor
-                                        ?: it.backgroundColor
-                                    ).toUIColor()
+                                it.iOSWebSettings.underPageBackgroundColor
+                                    ?: it.backgroundColor
+                            ).toUIColor()
                         setOpaque(it.iOSWebSettings.opaque)
                         if (!it.iOSWebSettings.opaque) {
                             setBackgroundColor(backgroundColor)


### PR DESCRIPTION
This commit updates the iOS WebView implementation to conditionally set the `inspectable` property on `WKWebView`.

The `setInspectable` method is only called if the operating system version is iOS 16.4 or later. This prevents potential crashes on older iOS versions where this method is not available.