### PR TITLE
Don't run evaluateJavascript inside the webView.post callback

### DIFF
--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AndroidWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AndroidWebView.kt
@@ -105,9 +105,7 @@ class AndroidWebView(
         KLogger.d {
             "evaluateJavaScript: $androidScript"
         }
-        webView.post {
-            webView.evaluateJavascript(androidScript, callback)
-        }
+        webView.evaluateJavascript(androidScript, callback)
     }
 
     override fun injectJsBridge() {


### PR DESCRIPTION
Calling WebView#post requires the WebView to be attached to the window making it impossible to use AndroidWebView in headless mode (without UI). The caller should use an appropriate thread to call evaluateJavaScript on.