### PR TITLE
bug(desktop): Fix macOS Desktop crash

### DIFF
--- a/README.desktop.md
+++ b/README.desktop.md
@@ -84,15 +84,20 @@ Make sure to include platform-required Flags to your compose configuration: [Dat
 compose.desktop {
   application {
     // all your other configuration, etc
-
-    jvmArgs("--add-opens", "java.desktop/sun.awt=ALL-UNNAMED")
-    jvmArgs("--add-opens", "java.desktop/java.awt.peer=ALL-UNNAMED") // recommended but not necessary
-
-    if (System.getProperty("os.name").contains("Mac")) {
-      jvmArgs("--add-opens", "java.desktop/sun.lwawt=ALL-UNNAMED")
-      jvmArgs("--add-opens", "java.desktop/sun.lwawt.macosx=ALL-UNNAMED")
-    }
   }
+}
+
+afterEvaluate {
+    tasks.withType<JavaExec> {
+        jvmArgs("--add-opens", "java.desktop/sun.awt=ALL-UNNAMED")
+        jvmArgs("--add-opens", "java.desktop/java.awt.peer=ALL-UNNAMED")
+
+        if (System.getProperty("os.name").contains("Mac")) {
+            jvmArgs("--add-opens", "java.desktop/sun.awt=ALL-UNNAMED")
+            jvmArgs("--add-opens", "java.desktop/sun.lwawt=ALL-UNNAMED")
+            jvmArgs("--add-opens", "java.desktop/sun.lwawt.macosx=ALL-UNNAMED")
+        }
+    }
 }
 ```
 ## ProGuard


### PR DESCRIPTION
Refactor JVM arguments for macOS compatibility and organization.

This fixed the error dialog:
```error
class org.cef.browser.mac.CefBrowserWindowMac (in unnamed module @0x673bfdf3) 
cannot access class sun.awt.AWTAccessor (in module java.desktop) because module
java.desktop does not export sun.awt to unnamed module @0x673bfdf3
```
When running on Desktop. iOS was working fine

Note: I had to do it this way *exactly* from the sample app to get it to work on macOS Tahoe 26. No idea why or if the OS matters. It does have one additional JVM argument compared to the original instructions.