### PR TITLE
Feat: Add Console bridge for android

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ android.minSdk=21
 #Versions
 GROUP=io.github.kevinnzou
 POM_ARTIFACT_ID=compose-webview-multiplatform
-VERSION_NAME=2.0.3
+VERSION_NAME=2.0.4
 POM_NAME=Compose WebView Multiplatform
 POM_INCEPTION_YEAR=2023
 POM_DESCRIPTION=WebView for JetBrains Compose Multiplatform

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/util/InternalStoragePathHandler.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/util/InternalStoragePathHandler.kt
@@ -1,6 +1,5 @@
 package com.multiplatform.webview.util
 
-import android.util.Log
 import android.webkit.WebResourceResponse
 import androidx.webkit.WebViewAssetLoader
 import java.io.File
@@ -8,7 +7,6 @@ import java.io.FileInputStream
 
 class InternalStoragePathHandler : WebViewAssetLoader.PathHandler {
     override fun handle(path: String): WebResourceResponse? {
-        Log.d("InternalStorageHandler", "Intercepted: $path")
         val file = File(path.removePrefix("/"))
         if (!file.exists() || !file.isFile) return null
 

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AndroidWebView.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/AndroidWebView.kt
@@ -2,6 +2,7 @@ package com.multiplatform.webview.web
 
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.JsMessage
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import com.multiplatform.webview.util.KLogger
@@ -21,6 +22,7 @@ class AndroidWebView(
     override val webView: WebView,
     override val scope: CoroutineScope,
     override val webViewJsBridge: WebViewJsBridge?,
+    override val consoleBridge: ConsoleBridge?,
 ) : IWebView {
     init {
         initWebView()

--- a/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
+++ b/webview/src/androidMain/kotlin/com/multiplatform/webview/web/WebView.android.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 
 /**
@@ -17,6 +18,7 @@ actual fun ActualWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
+    consoleBridge: ConsoleBridge?,
     onCreated: (NativeWebView) -> Unit,
     onDispose: (NativeWebView) -> Unit,
     platformWebViewParams: PlatformWebViewParams?,
@@ -28,6 +30,7 @@ actual fun ActualWebView(
         captureBackPresses,
         navigator,
         webViewJsBridge,
+        consoleBridge,
         onCreated = onCreated,
         onDispose = onDispose,
         client = platformWebViewParams?.client ?: remember { AccompanistWebViewClient() },

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/jsbridge/ConsoleBridge.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/jsbridge/ConsoleBridge.kt
@@ -1,0 +1,72 @@
+package com.multiplatform.webview.jsbridge
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Bridge for capturing platform WebView console logs and forwarding them to
+ * the existing JS bridge as a JSON payload matching ConsoleLogMessage structure.
+ */
+class ConsoleBridge(
+    /**
+     * Callback invoked with a JSON string matching ConsoleLogMessage schema.
+     */
+    var onLog: ((String) -> Unit)? = null,
+) {
+    /**
+     * Emit a console log event coming from the platform WebView.
+     * This will be routed through the JS bridge using method "consoleLog".
+     */
+    fun emitFromPlatform(
+        level: String,
+        content: String,
+        sourceId: String?,
+        lineNumber: Int,
+        timestamp: String,
+    ) {
+        val normalizedLevel = level.lowercase()
+        val type =
+            when (normalizedLevel) {
+                "error" -> "error"
+                "exception" -> "exception"
+                else -> "normal"
+            }
+        val cause =
+            when (normalizedLevel) {
+                "warn", "warning" -> "warning"
+                "error" -> "error"
+                "debug" -> "debug"
+                else -> "user_code"
+            }
+        val emoji =
+            when (normalizedLevel) {
+                "error" -> "❌"
+                "warn", "warning" -> "⚠️"
+                "debug" -> "🔍"
+                "info" -> "ℹ️"
+                else -> "📝"
+            }
+        val filePath = sourceId ?: ""
+        val fileName = filePath.substringAfterLast('/').substringAfterLast('\\')
+
+        val json: JsonObject =
+            buildJsonObject {
+                put("emoji", emoji)
+                put("type", type)
+                put("level", normalizedLevel)
+                put("content", content)
+                put("cause", cause)
+                put("lineNumber", lineNumber)
+                put("fileName", fileName)
+                put("filePath", filePath)
+                put("timestamp", timestamp)
+            }
+
+        val payload = Json.encodeToString(JsonObject.serializer(), json)
+
+        // Emit directly to any listener without using WebViewJsBridge
+        onLog?.invoke(payload)
+    }
+}

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/IWebView.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/IWebView.kt
@@ -1,10 +1,11 @@
 package com.multiplatform.webview.web
 
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import com.multiplatform.webview.util.KLogger
-import compose_webview_multiplatform.webview.generated.resources.Res
 import kotlinx.coroutines.CoroutineScope
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import ybee.libs.webview.generated.resources.Res
 
 /**
  * Created By Kevin Zou On 2023/9/5
@@ -25,6 +26,8 @@ interface IWebView {
     val scope: CoroutineScope
 
     val webViewJsBridge: WebViewJsBridge?
+
+    val consoleBridge: ConsoleBridge?
 
     /**
      * True when the web view is able to navigate backwards, false otherwise.
@@ -187,13 +190,11 @@ interface IWebView {
                     };
                     if (callback) {
                         window.$jsBridgeName.callbacks[message.callbackId] = callback;
-                        console.log('add callback: ' + message.callbackId + ', ' + callback);
                     }
                     window.$jsBridgeName.postMessage(JSON.stringify(message));
                 },
                 onCallback: function (callbackId, data) {
                     var callback = window.$jsBridgeName.callbacks[callbackId];
-                    console.log('onCallback: ' + callbackId + ', ' + data + ', ' + callback);
                     if (callback) {
                         callback(data);
                         delete window.$jsBridgeName.callbacks[callbackId];

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/IWebView.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/IWebView.kt
@@ -3,9 +3,9 @@ package com.multiplatform.webview.web
 import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import com.multiplatform.webview.util.KLogger
+import compose_webview_multiplatform.webview.generated.resources.Res
 import kotlinx.coroutines.CoroutineScope
 import org.jetbrains.compose.resources.ExperimentalResourceApi
-import ybee.libs.webview.generated.resources.Res
 
 /**
  * Created By Kevin Zou On 2023/9/5

--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.merge
@@ -35,6 +36,7 @@ fun WebView(
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewJsBridge: WebViewJsBridge? = null,
+    consoleBridge: ConsoleBridge? = null,
     onCreated: () -> Unit = {},
     onDispose: () -> Unit = {},
     platformWebViewParams: PlatformWebViewParams? = null,
@@ -45,6 +47,7 @@ fun WebView(
         captureBackPresses = captureBackPresses,
         navigator = navigator,
         webViewJsBridge = webViewJsBridge,
+        consoleBridge = consoleBridge,
         onCreated = { _ -> onCreated() },
         onDispose = { _ -> onDispose() },
         platformWebViewParams = platformWebViewParams,
@@ -72,6 +75,7 @@ fun WebView(
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewJsBridge: WebViewJsBridge? = null,
+    consoleBridge: ConsoleBridge? = null,
     onCreated: (NativeWebView) -> Unit = {},
     onDispose: (NativeWebView) -> Unit = {},
     platformWebViewParams: PlatformWebViewParams? = null,
@@ -118,6 +122,7 @@ fun WebView(
         captureBackPresses = captureBackPresses,
         navigator = navigator,
         webViewJsBridge = webViewJsBridge,
+        consoleBridge = consoleBridge,
         onCreated = onCreated,
         onDispose = onDispose,
         platformWebViewParams = platformWebViewParams,
@@ -167,6 +172,7 @@ expect fun ActualWebView(
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewJsBridge: WebViewJsBridge? = null,
+    consoleBridge: ConsoleBridge? = null,
     onCreated: (NativeWebView) -> Unit = {},
     onDispose: (NativeWebView) -> Unit = {},
     platformWebViewParams: PlatformWebViewParams? = null,

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/DesktopWebView.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/DesktopWebView.kt
@@ -1,5 +1,6 @@
 package com.multiplatform.webview.web
 
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.JsMessage
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import com.multiplatform.webview.util.KLogger
@@ -358,6 +359,8 @@ class DesktopWebView(
 
         return modifiedHtml
     }
+
+    override val consoleBridge: ConsoleBridge? = null
 
     override fun saveState(): WebViewBundle? = null
 

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebView.desktop.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/WebView.desktop.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import dev.datlag.kcef.KCEF
 import dev.datlag.kcef.KCEFBrowser
@@ -26,6 +27,7 @@ actual fun ActualWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
+    consoleBridge: ConsoleBridge?,
     onCreated: (NativeWebView) -> Unit,
     onDispose: (NativeWebView) -> Unit,
     platformWebViewParams: PlatformWebViewParams?,

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/IOSWebView.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/IOSWebView.kt
@@ -1,5 +1,6 @@
 package com.multiplatform.webview.web
 
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WKJsMessageHandler
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import com.multiplatform.webview.util.KLogger
@@ -273,6 +274,8 @@ class IOSWebView(
             return Pair(x.toInt(), y.toInt())
         }
     }
+
+    override val consoleBridge: ConsoleBridge? = null
 
     private class BundleMarker : NSObject() {
         companion object : NSObjectMeta()

--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import com.multiplatform.webview.util.toUIColor
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -30,6 +31,7 @@ actual fun ActualWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
+    consoleBridge: ConsoleBridge?,
     onCreated: (NativeWebView) -> Unit,
     onDispose: (NativeWebView) -> Unit,
     platformWebViewParams: PlatformWebViewParams?,

--- a/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WasmJsWebView.kt
+++ b/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WasmJsWebView.kt
@@ -1,5 +1,6 @@
 package com.multiplatform.webview.web
 
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -213,6 +214,8 @@ class WasmJsWebView(
     override fun initJsBridge(webViewJsBridge: WebViewJsBridge) {
         // Bridge initialization is handled externally
     }
+
+    override val consoleBridge: ConsoleBridge? = null
 
     override fun saveState(): WebViewBundle? = null
 

--- a/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WebView.wasmJs.kt
+++ b/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WebView.wasmJs.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import com.multiplatform.webview.jsbridge.ConsoleBridge
 import com.multiplatform.webview.jsbridge.WebViewJsBridge
 import kotlinx.browser.document
 import kotlinx.coroutines.launch
@@ -153,6 +154,7 @@ actual fun ActualWebView(
     captureBackPresses: Boolean,
     navigator: WebViewNavigator,
     webViewJsBridge: WebViewJsBridge?,
+    consoleBridge: ConsoleBridge?,
     onCreated: (NativeWebView) -> Unit,
     onDispose: (NativeWebView) -> Unit,
     platformWebViewParams: PlatformWebViewParams?,


### PR DESCRIPTION
-Introduce ConsoleBridge for console log capture (Android Only) and update version

Fix:
Remove tap highlight color in android.

This commit introduces a `ConsoleBridge` to capture console logs from the platform WebView and forward them as JSON payloads.

**JS Bridge:**
- Added `ConsoleBridge.kt` (commonMain) to handle console log capturing. It formats log messages (level, content, source, line number, timestamp) into a JSON string and invokes an `onLog` callback.
- `IWebView.kt` (commonMain): Added `consoleBridge` property. Removed console logging from the default JS bridge script.
- All platform-specific `WebView.platform.kt` and `ActualWebView.kt` implementations now accept and store a `ConsoleBridge?` instance.
- `DesktopWebView.kt`, `IOSWebView.kt`, `WasmJsWebView.kt`: Implemented `consoleBridge` property, returning `null` for now as console capturing is not yet implemented for these platforms.

**Android:**
- `AccompanistWebView.kt`:
    - Now accepts a `consoleBridge: ConsoleBridge?` parameter.
    - Passes the `consoleBridge` to the `AndroidWebView` instance.
    - Implemented `onConsoleMessage` in `AccompanistWebChromeClient` to capture console messages. It formats the message using `ConsoleBridge.emitFromPlatform` if a `consoleBridge` is available.
    - Added JavaScript execution to remove the default tap highlight color on Android WebViews for a cleaner user experience.
    - Changed `PlatformWebSettings.AndroidWebSettings.LayerType` mapping to use explicit `View.LAYER_TYPE_*` constants.
- `AndroidWebView.kt`: Now accepts and stores a `consoleBridge: ConsoleBridge?`.
- `InternalStoragePathHandler.kt`: Removed debug logging.

**Build:**
- Incremented `VERSION_NAME` to `2.0.4`.