### PR TITLE
bugfix: WebView not ignoring safe area in full-screen mode on iOS

### DIFF
--- a/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
+++ b/webview/src/iosMain/kotlin/com/multiplatform/webview/web/WebView.ios.kt
@@ -151,12 +151,8 @@ fun IOSWebView(
                             scrollEnabled = it.scrollEnabled
                             showsHorizontalScrollIndicator = it.showHorizontalScrollIndicator
                             showsVerticalScrollIndicator = it.showVerticalScrollIndicator
-                            if (
-                                platform.UIKit.UIDevice.currentDevice.systemVersion
-                                    .toDouble() >= 11.0
-                            ) {
-                                contentInsetAdjustmentBehavior = platform.UIKit.UIScrollViewContentInsetAdjustmentBehavior.UIScrollViewContentInsetAdjustmentNever
-                            }
+                            contentInsetAdjustmentBehavior =
+                                platform.UIKit.UIScrollViewContentInsetAdjustmentBehavior.UIScrollViewContentInsetAdjustmentNever
                         }
                     }
 


### PR DESCRIPTION
When embedding a full-screen `WebView` in **Compose Multiplatform on iOS**, the view does not correctly ignore the safe area.

Even if the SwiftUI hosting side applies:

```swift
struct ContentView: View {
    var body: some View {
        ComposeView()
            .ignoresSafeArea(.all)
    }
}
```

…the `WebView` is still inset by iOS safe areas.

**Before (safe area respected incorrectly):** <img width="282" height="552" alt="image" src="https://github.com/user-attachments/assets/ff4b9ac6-ce30-4d48-b7be-1aa9249b50a8" />

After investigating related issues (#159), I found that the problem began after introducing a `ScrollView` wrapper. By default, `UIScrollView` always respects the safe area insets, even if Compose requests to ignore them.

### Solution

The fix is to explicitly disable automatic content inset adjustment for the underlying `UIScrollView`. We can do this by setting:

```kotlin
contentInsetAdjustmentBehavior = platform.UIKit.UIScrollViewContentInsetAdjustmentBehavior.UIScrollViewContentInsetAdjustmentNever
```

**After (expected full-screen WebView):** <img width="282" height="552" alt="image" src="https://github.com/user-attachments/assets/1d214e7c-bd63-44e3-bf46-2867b94b22fb" />

This allows to manage safe area handling (e.g., with `.ignoresSafeArea(.all)` or `.ignoresSafeArea(.keyboard)` or Compose itself) instead of iOS forcing additional insets.

This fix was tested with a modified version of HtmlWebViewSample.kt:

```kotlin
@Composable
internal fun BasicWebViewWithHTMLSample(navHostController: NavHostController? = null) {
    val webViewState =
        rememberWebViewStateWithHTMLFile(
            fileName = Res.getUri("files/samples/index.html"),
            readType = WebViewFileReadType.COMPOSE_RESOURCE_FILES,
        )
    val webViewNavigator = rememberWebViewNavigator()
    val jsBridge = rememberWebViewJsBridge(webViewNavigator)

    LaunchedEffect(Unit) {
        initWebView(webViewState)
        initJsBridge(jsBridge)
    }

    MaterialTheme {
        WebView(
            state = webViewState,
            modifier = Modifier.fillMaxSize(),
            captureBackPresses = false,
            navigator = webViewNavigator,
            webViewJsBridge = jsBridge,
        )
    }
}
```

Related Issues:
#159
#287