### PR TITLE
(Desktop) Set UA via request handler instead of context: Fixes CookieManager

### DIFF
--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/CefRequestExt.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/CefRequestExt.kt
@@ -4,23 +4,36 @@ import com.multiplatform.webview.setting.WebSettings
 import dev.datlag.kcef.KCEFResourceRequestHandler
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
-import org.cef.browser.CefRequestContext
+import org.cef.handler.CefRequestHandler
+import org.cef.handler.CefRequestHandlerAdapter
+import org.cef.handler.CefResourceRequestHandler
+import org.cef.misc.BoolRef
 import org.cef.network.CefRequest
 
-internal fun createModifiedRequestContext(settings: WebSettings): CefRequestContext {
-    return CefRequestContext.createContext { browser, frame, request, isNavigation, isDownload, requestInitiator, disableDefaultHandling ->
-        object : KCEFResourceRequestHandler(
-            getGlobalDefaultHandler(browser, frame, request, isNavigation, isDownload, requestInitiator, disableDefaultHandling),
-        ) {
-            override fun onBeforeResourceLoad(
-                browser: CefBrowser?,
-                frame: CefFrame?,
-                request: CefRequest?,
-            ): Boolean {
-                if (request != null) {
-                    settings.customUserAgentString?.let(request::setUserAgentString)
+internal fun createModifiedRequestHandler(settings: WebSettings): CefRequestHandler {
+    return object : CefRequestHandlerAdapter() {
+        override fun getResourceRequestHandler(
+            browser: CefBrowser?,
+            frame: CefFrame?,
+            request: CefRequest?,
+            isNavigation: Boolean,
+            isDownload: Boolean,
+            requestInitiator: String?,
+            disableDefaultHandling: BoolRef?,
+        ): CefResourceRequestHandler {
+            return object : KCEFResourceRequestHandler(
+                getGlobalDefaultHandler(browser, frame, request, isNavigation, isDownload, requestInitiator, disableDefaultHandling),
+            ) {
+                override fun onBeforeResourceLoad(
+                    browser: CefBrowser?,
+                    frame: CefFrame?,
+                    request: CefRequest?,
+                ): Boolean {
+                    if (request != null) {
+                        settings.customUserAgentString?.let(request::setUserAgentString)
+                    }
+                    return super.onBeforeResourceLoad(browser, frame, request)
                 }
-                return super.onBeforeResourceLoad(browser, frame, request)
             }
         }
     }


### PR DESCRIPTION
**This PR removes the modified request context from desktop webviews.**

The modified request context was previously used only to apply `WebSettings.customUserAgentString`, but had the unintended side-effect of delegating all cookies to the modified `CefRequestContext`'s cookie manager. 
- Since a new request context was being created every time a WebView was created, cookies were effectively transient
- Since `WebViewState.getCookieManager()` uses the global cookie manager, it was unable to access cookies within modified request context

--

**This PR instead applies the user agent by adding a `CefRequestHandler`, which does not separate cookies.**

This approach still applies the user agent without any apparent downsides.
- The global cookie manager is used, and `WebViewState.getCookieManager()` works as expected.
- Cookies are now persistent and shared between WebViews on desktop. This seems to be consistent with other platforms. 

Resolves #395, #152 